### PR TITLE
[BW] Remove unwanted check on iOS version

### DIFF
--- a/Clickable links/MainViewController.swift
+++ b/Clickable links/MainViewController.swift
@@ -36,7 +36,7 @@ class MainViewController: UIViewController {
         super.traitCollectionDidChange(previousTraitCollection)
 
         if traitCollection.userInterfaceStyle == .dark {
-            
+
             gradientLayer.removeFromSuperlayer()
             backgroundView.backgroundColor = UIColor(named: "backgroundColor")
 
@@ -56,12 +56,10 @@ class MainViewController: UIViewController {
         let infoButtonColor = UIColor(named: "navTitleColor")
         navBarInfo.tintColor = infoButtonColor
 
-        if #available(iOS 12.0, *) {
-            if traitCollection.userInterfaceStyle == .light {
-                insertGradientLayer(gradientLayer, backgroundView: backgroundView)
-            } else {
-                backgroundView.backgroundColor = UIColor(named: "backgroundColor")
-            }
+        if traitCollection.userInterfaceStyle == .light {
+            insertGradientLayer(gradientLayer, backgroundView: backgroundView)
+        } else {
+            backgroundView.backgroundColor = UIColor(named: "backgroundColor")
         }
     }
 }


### PR DESCRIPTION
As the minimum iOS version has been bumped to iOS12, there is no longer need to have specific behavior bellow that version. This PR remove some remaining `if #available(iOS 12.0, *)`