### PR TITLE
[BW] Add examples of how to present messaging view modally

### DIFF
--- a/ClickableLinks/MainViewController.swift
+++ b/ClickableLinks/MainViewController.swift
@@ -153,6 +153,14 @@ extension MainViewController {
             guard let viewController = Zendesk.instance?.messaging?.messagingViewController() else { return }
             self.navigationController?.show(viewController, sender: self)
 
+            // This is an alternative way to present the messaging view controller using modal presention.
+            // When presenting modally, the messaging view controller needs to be in a navigation controller to work properly.
+//            self.navigationController?.present(
+//                UINavigationController(rootViewController: viewController),
+//                animated: true,
+//                completion: nil
+//            )
+
         }
         return cell
     }

--- a/HelloWorld/MainViewController.swift
+++ b/HelloWorld/MainViewController.swift
@@ -98,7 +98,7 @@ extension MainViewController {
             return UITableViewCell()
         }
 #warning("provide channel key")
-        let channel_key = "eyJzZXR0aW5nc191cmwiOiJodHRwczovL3o0bm5tdGVzdGFwcC56ZW5kZXNrLmNvbS9tb2JpbGVfc2RrX2FwaS9zZXR0aW5ncy8wMUhXN0hQUFlKRDNaNkJNNVQ5TlNNOThaNS5qc29uIn0="
+        let channel_key = ""
 
         cell.clickHandler = {[weak self] in
             guard let self = self else { return }

--- a/HelloWorld/MainViewController.swift
+++ b/HelloWorld/MainViewController.swift
@@ -98,8 +98,8 @@ extension MainViewController {
             return UITableViewCell()
         }
 #warning("provide channel key")
-        let channel_key = ""
-        
+        let channel_key = "eyJzZXR0aW5nc191cmwiOiJodHRwczovL3o0bm5tdGVzdGFwcC56ZW5kZXNrLmNvbS9tb2JpbGVfc2RrX2FwaS9zZXR0aW5ncy8wMUhXN0hQUFlKRDNaNkJNNVQ5TlNNOThaNS5qc29uIn0="
+
         cell.clickHandler = {[weak self] in
             guard let self = self else { return }
 #warning("Basic init code with a custom alert in case of failure, and a custom toast in case of success.")
@@ -126,6 +126,14 @@ extension MainViewController {
 #warning("Basic conversation presentation via the navigation controller.")
             guard let viewController = Zendesk.instance?.messaging?.messagingViewController() else { return }
             self.navigationController?.show(viewController, sender: self)
+
+            // This is an alternative way to present the messaging view controller using modal presention.
+            // When presenting modally, the messaging view controller needs to be in a navigation controller to work properly.
+//            self.navigationController?.present(
+//                UINavigationController(rootViewController: viewController),
+//                animated: true,
+//                completion: nil
+//            )
         }
         return cell
     }

--- a/JWTAuth/MainViewController.swift
+++ b/JWTAuth/MainViewController.swift
@@ -135,6 +135,14 @@ extension MainViewController {
 #warning("Basic conversation presentation via the navigation controller.")
             guard let viewController = Zendesk.instance?.messaging?.messagingViewController() else { return }
             self.navigationController?.show(viewController, sender: self)
+
+            // This is an alternative way to present the messaging view controller using modal presention.
+            // When presenting modally, the messaging view controller needs to be in a navigation controller to work properly.
+//            self.navigationController?.present(
+//                UINavigationController(rootViewController: viewController),
+//                animated: true,
+//                completion: nil
+//            )
         }
         return cell
     }

--- a/Metadata/MainViewController.swift
+++ b/Metadata/MainViewController.swift
@@ -141,6 +141,14 @@ extension MainViewController {
 #warning("Basic conversation presentation via the navigation controller.")
             guard let viewController = Zendesk.instance?.messaging?.messagingViewController() else { return }
             self.navigationController?.show(viewController, sender: self)
+
+            // This is an alternative way to present the messaging view controller using modal presention.
+            // When presenting modally, the messaging view controller needs to be in a navigation controller to work properly.
+//            self.navigationController?.present(
+//                UINavigationController(rootViewController: viewController),
+//                animated: true,
+//                completion: nil
+//            )
         }
         return cell
     }

--- a/PushNotifications/MainViewController.swift
+++ b/PushNotifications/MainViewController.swift
@@ -131,6 +131,14 @@ extension MainViewController {
 #warning("Basic conversation presentation via the navigation controller.")
             guard let viewController = Zendesk.instance?.messaging?.messagingViewController() else { return }
             self.navigationController?.show(viewController, sender: self)
+
+            // This is an alternative way to present the messaging view controller using modal presention.
+            // When presenting modally, the messaging view controller needs to be in a navigation controller to work properly.
+//            self.navigationController?.present(
+//                UINavigationController(rootViewController: viewController),
+//                animated: true,
+//                completion: nil
+//            )
         }
         return cell
     }

--- a/SwiftUIIntegration/ContentView.swift
+++ b/SwiftUIIntegration/ContentView.swift
@@ -28,6 +28,7 @@ struct ContentView: View {
     }
     @State private var pageViewTitle: String = ""
     @State private var pageViewUrl: String = ""
+    @State private var isPresentingMessagingModally = false
 
     private let logger = Logger(subsystem: Constants.bundleIdentifier, category: Constants.category)
 
@@ -51,6 +52,13 @@ struct ContentView: View {
                         })
                         NavigationLink(destination: MessagingView()) {
                             InfoBannerView.showMessaging
+                        }
+                        .disabled(!isInitialized)
+                        .opacity(isInitialized ? 1 : 0.5)
+                        Button {
+                            isPresentingMessagingModally = true
+                        } label: {
+                            Text("Present Messaging Modally")
                         }
                         .disabled(!isInitialized)
                         .opacity(isInitialized ? 1 : 0.5)
@@ -86,12 +94,18 @@ struct ContentView: View {
                 .navigationTitle("Zendesk SDK Demo App")
                 .navigationBarTitleDisplayMode(.inline)
             }
+            .onAppear {
+                // Existing Zendesk instance is invalidated to avoid any conflicts between the push and the modal presentation.
+                // This is not necessary in a real-world scenario when only one presentation method is used.
+                Zendesk.invalidate(false)
+                if !channelKey.isEmpty {
+                    initializeZendeskSDK()
+                }
+            }
         }
         .navigationViewStyle(StackNavigationViewStyle())
-        .onAppear {
-            if !channelKey.isEmpty {
-                initializeZendeskSDK()
-            }
+        .sheet(isPresented: $isPresentingMessagingModally) {
+            MessagingView(isModal: true)
         }
     }
 

--- a/SwiftUIIntegration/Localizable.xcstrings
+++ b/SwiftUIIntegration/Localizable.xcstrings
@@ -43,6 +43,9 @@
     "Page view URL" : {
 
     },
+    "Present Messaging Modally" : {
+
+    },
     "Send Page View Event" : {
 
     },

--- a/SwiftUIIntegration/MessagingView.swift
+++ b/SwiftUIIntegration/MessagingView.swift
@@ -12,14 +12,21 @@ import ZendeskSDKMessaging
 
 /// A `View` that wraps the `MessagingViewController`.
 struct MessagingView: View {
-    init() {
-        #if DEBUG
+
+    let isModal: Bool
+
+    init(isModal: Bool = false) {
+#if DEBUG
         Logger.enabled = true
-        #endif
+#endif
+        self.isModal = isModal
     }
+
     var body: some View {
-        ViewControllerWrapper(viewController: Zendesk.instance?.messaging?.messagingViewController())
-            .ignoresSafeArea()
+        ViewControllerWrapper(
+            viewController: Zendesk.instance?.messaging?.messagingViewController(),
+            isModal: isModal
+        ).ignoresSafeArea()
     }
 }
 
@@ -34,9 +41,19 @@ struct MessagingNotificationView: View {
 /// A `UIViewControllerRepresentable` that wraps a `UIViewController`.
 struct ViewControllerWrapper: UIViewControllerRepresentable {
     var viewController: UIViewController?
+    let isModal: Bool
+
+    init(viewController: UIViewController?, isModal: Bool = false) {
+        self.viewController = viewController
+        self.isModal = isModal
+    }
 
     func makeUIViewController(context: Context) -> UIViewController {
-        viewController ?? ErrorViewController()
+        if isModal {
+            UINavigationController(rootViewController: viewController ?? ErrorViewController())
+        } else {
+            viewController ?? ErrorViewController()
+        }
     }
 
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {

--- a/VisitorPath/MainViewController.swift
+++ b/VisitorPath/MainViewController.swift
@@ -135,6 +135,14 @@ extension MainViewController {
             guard let viewController = Zendesk.instance?.messaging?.messagingViewController() else { return }
             self.navigationController?.show(viewController, sender: self)
 
+            // This is an alternative way to present the messaging view controller using modal presention.
+            // When presenting modally, the messaging view controller needs to be in a navigation controller to work properly.
+//            self.navigationController?.present(
+//                UINavigationController(rootViewController: viewController),
+//                animated: true,
+//                completion: nil
+//            )
+
             // Create a `PageView` object
             let pageView = PageView(pageTitle: "example", url: "example.com")
             Zendesk.instance?.sendPageViewEvent(pageView) { result in


### PR DESCRIPTION
## Description 
This pull request includes several examples of modally presenting the messaging view controller in existing targer.
It also adds a new button to present the messaging view controller modally in the SwiftUI integration. 

### Improvements to presentation of messaging view controller:

Added commented-out alternative code to present the messaging view controller using modal presentation in:
* `ClickableLinks/MainViewController.swift`, 
* `HelloWorld/MainViewController.swift`, 
* `JWTAuth/MainViewController.swift`, 
* `Metadata/MainViewController.swift`, 
* `PushNotifications/MainViewController.swift`, 
* `VisitorPath/MainViewController.swift`

### SwiftUI integration updates:

* `SwiftUIIntegration/ContentView.swift`: Added a new state variable `isPresentingMessagingModally` and a button to present the messaging view controller modally. Updated the navigation view style and added a sheet presentation for the messaging view.
* `SwiftUIIntegration/MessagingView.swift`: Updated the `MessagingView` and `ViewControllerWrapper` to support modal presentation by adding an `isModal` parameter and handling the modal presentation logic.